### PR TITLE
BCMOHAD-27312- Required field added for the UPSERT operation-Data Mapper

### DIFF
--- a/src/main/default/omniDataTransforms/DRUpdateRegCodeViolationRecords_1.rpt-meta.xml
+++ b/src/main/default/omniDataTransforms/DRUpdateRegCodeViolationRecords_1.rpt-meta.xml
@@ -96,43 +96,16 @@
     <name>DRUpdateRegCodeViolationRecords</name>
     <nullInputsIncludedInOutput>false</nullInputsIncludedInOutput>
     <omniDataTransformItem>
-        <disabled>false</disabled>
+        <disabled>true</disabled>
         <filterGroup>0.0</filterGroup>
-        <globalKey>DRUpdateRegCodeViolationRecordsCustom3140</globalKey>
-        <inputFieldName>SingleListJSON:Id</inputFieldName>
+        <filterOperator>=</filterOperator>
+        <globalKey>DRUpdateRegCodeViolationRecordsCustom4149</globalKey>
         <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
         <linkedObjectSequence>0.0</linkedObjectSequence>
+        <migrationValue>FAKEMAPPING</migrationValue>
         <name>DRUpdateRegCodeViolationRecords</name>
         <outputCreationSequence>1.0</outputCreationSequence>
         <outputFieldName>Id</outputFieldName>
-        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
-        <requiredForUpsert>false</requiredForUpsert>
-        <upsertKey>false</upsertKey>
-    </omniDataTransformItem>
-    <omniDataTransformItem>
-        <disabled>false</disabled>
-        <filterGroup>0.0</filterGroup>
-        <globalKey>DRUpdateRegCodeViolationRecordsCustom1010</globalKey>
-        <inputFieldName>SingleListJSON:RiskScore</inputFieldName>
-        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
-        <linkedObjectSequence>0.0</linkedObjectSequence>
-        <name>DRUpdateRegCodeViolationRecords</name>
-        <outputCreationSequence>1.0</outputCreationSequence>
-        <outputFieldName>UserScore__c</outputFieldName>
-        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
-        <requiredForUpsert>false</requiredForUpsert>
-        <upsertKey>false</upsertKey>
-    </omniDataTransformItem>
-    <omniDataTransformItem>
-        <disabled>false</disabled>
-        <filterGroup>0.0</filterGroup>
-        <globalKey>DRUpdateRegCodeViolationRecordsCustom8512</globalKey>
-        <inputFieldName>SingleListJSON:Description</inputFieldName>
-        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
-        <linkedObjectSequence>0.0</linkedObjectSequence>
-        <name>DRUpdateRegCodeViolationRecords</name>
-        <outputCreationSequence>1.0</outputCreationSequence>
-        <outputFieldName>Description</outputFieldName>
         <outputObjectName>RegulatoryCodeViolation</outputObjectName>
         <requiredForUpsert>false</requiredForUpsert>
         <upsertKey>false</upsertKey>
@@ -166,13 +139,55 @@
         <upsertKey>false</upsertKey>
     </omniDataTransformItem>
     <omniDataTransformItem>
-        <disabled>true</disabled>
+        <disabled>false</disabled>
         <filterGroup>0.0</filterGroup>
-        <filterOperator>=</filterOperator>
-        <globalKey>DRUpdateRegCodeViolationRecordsCustom4149</globalKey>
+        <globalKey>DRUpdateRegCodeViolationRecordsCustom1010</globalKey>
+        <inputFieldName>SingleListJSON:RiskScore</inputFieldName>
         <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
         <linkedObjectSequence>0.0</linkedObjectSequence>
-        <migrationValue>FAKEMAPPING</migrationValue>
+        <name>DRUpdateRegCodeViolationRecords</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>UserScore__c</outputFieldName>
+        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>DRUpdateRegCodeViolationRecordsCustom4778</globalKey>
+        <inputFieldName>SingleListJSON:DateCreated</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>DRUpdateRegCodeViolationRecords</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldFormat>Date(MM/dd/yyyy)</outputFieldFormat>
+        <outputFieldName>DateCreated</outputFieldName>
+        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
+        <requiredForUpsert>true</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>DRUpdateRegCodeViolationRecordsCustom8512</globalKey>
+        <inputFieldName>SingleListJSON:Description</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>DRUpdateRegCodeViolationRecords</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>Description</outputFieldName>
+        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>DRUpdateRegCodeViolationRecordsCustom3140</globalKey>
+        <inputFieldName>SingleListJSON:Id</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
         <name>DRUpdateRegCodeViolationRecords</name>
         <outputCreationSequence>1.0</outputCreationSequence>
         <outputFieldName>Id</outputFieldName>

--- a/src/main/default/omniDataTransforms/DRUpdateSingleScore_1.rpt-meta.xml
+++ b/src/main/default/omniDataTransforms/DRUpdateSingleScore_1.rpt-meta.xml
@@ -10,21 +10,6 @@
     <name>DRUpdateSingleScore</name>
     <nullInputsIncludedInOutput>false</nullInputsIncludedInOutput>
     <omniDataTransformItem>
-        <disabled>true</disabled>
-        <filterGroup>0.0</filterGroup>
-        <filterOperator>=</filterOperator>
-        <globalKey>DRUpdateSingleScoreCustom1879</globalKey>
-        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
-        <linkedObjectSequence>0.0</linkedObjectSequence>
-        <migrationValue>FAKEMAPPING</migrationValue>
-        <name>DRUpdateSingleScore</name>
-        <outputCreationSequence>1.0</outputCreationSequence>
-        <outputFieldName>Id</outputFieldName>
-        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
-        <requiredForUpsert>false</requiredForUpsert>
-        <upsertKey>false</upsertKey>
-    </omniDataTransformItem>
-    <omniDataTransformItem>
         <disabled>false</disabled>
         <filterGroup>0.0</filterGroup>
         <globalKey>DRUpdateSingleScoreCustom8733</globalKey>
@@ -45,6 +30,36 @@
         <inputFieldName>Questions1:Id</inputFieldName>
         <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
         <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>DRUpdateSingleScore</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>Id</outputFieldName>
+        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>DRUpdateSingleScoreCustom5747</globalKey>
+        <inputFieldName>Questions1:DateCreated</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>DRUpdateSingleScore</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldFormat>Date(MM/dd/yyyy)</outputFieldFormat>
+        <outputFieldName>DateCreated</outputFieldName>
+        <outputObjectName>RegulatoryCodeViolation</outputObjectName>
+        <requiredForUpsert>true</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>true</disabled>
+        <filterGroup>0.0</filterGroup>
+        <filterOperator>=</filterOperator>
+        <globalKey>DRUpdateSingleScoreCustom1879</globalKey>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <migrationValue>FAKEMAPPING</migrationValue>
         <name>DRUpdateSingleScore</name>
         <outputCreationSequence>1.0</outputCreationSequence>
         <outputFieldName>Id</outputFieldName>


### PR DESCRIPTION
Required field missing Issue found in other components for the data mapper post action added as well.
DRUpdateRegCodeViolationRecords_1.rpt-meta
DRUpdateSingleScore_1.rpt-meta