### PR TITLE
BCMOHAM-23732-2-Updating Code to pick the active template

### DIFF
--- a/bcgov-source/app-alr/main/default/classes/BCMOH_UtilityClass.cls
+++ b/bcgov-source/app-alr/main/default/classes/BCMOH_UtilityClass.cls
@@ -13,6 +13,7 @@ public with sharing class BCMOH_UtilityClass {
 * @description: The purpose of this method is to fetch renewal details FROM metadata
 * @return:  Map<String, List<String>>
 * @Modification Log: [Date] - [Change Reference] - [Changed By] - [Description]
+* @Modification Log: [27/03/2025] - [BCMOHAM-23732] - [CGI] - [Need to pick the active template from the list of templates]
 */
     public static Map<String, List<String>> getAccRenewals(String renewalName) {
         Map<String, List<String>> accDetails = new Map<String, List<String>>();
@@ -204,7 +205,7 @@ public with sharing class BCMOH_UtilityClass {
         Map<String, DocumentTemplateContentDoc> templateNameDocMap = new Map<String, DocumentTemplateContentDoc>();
         for(DocumentTemplateContentDoc docTempRec : [SELECT DocumentTemplate.Name, ContentDocument.Title, LatestContentVersionId
                                                      FROM DocumentTemplateContentDoc
-                                                     WHERE DocumentTemplate.Name IN: templateNames WITH SECURITY_ENFORCED 
+                                                     WHERE DocumentTemplate.Name IN: templateNames  and  DocumentTemplate.isActive= true WITH SECURITY_ENFORCED  
                                                      LIMIT 5000]) {
                                                          templateNameDocMap.put(docTempRec.DocumentTemplate.Name, docTempRec);
                                                      }


### PR DESCRIPTION
Description:
BCMOHAM-23732-2-Updating Code to pick the active template

Ticket: BCMOHAM-23732

PDS:
====
1) Switch to salesforce classic 
    Locate Librairies
    Drilldown on 'Docgen Document Template Library'
    Click on 'Edit Members 
    Add CGI Support 
   Click Next 
   Pick   'Library Administrator' from Library Permissions PickList

2) * Switch to lightning Experience 
      Go to Setup/Users /CGI Support:
          Assign below Permission Set:
                       DocGen User
                        DocGen Designer
    
          Go Setup / public group /Administrative Tasks Group / Edit /Search for User and Add CGI Support
    
          Go Setup / Queues /Administrative Tasks / Edit /Search for User and Add CGI Support

3) From App Launcher choose 'Document Template Designer'
      Find 'LateFee_Template'
      Click on the Active One 
      Click on Button Deactivate Template
      Click on Replace File
      Browse for the attached file 'Late Fee Invoice.docx'
      Click on Save and then Activate