### PR TITLE
BCMOHAD-29533 Updated the flow to prevent the duplicate inspection creation

### DIFF
--- a/bcgov-source/app-alr/main/default/flows/InitialCmplianceInspCreation.flow-meta.xml
+++ b/bcgov-source/app-alr/main/default/flows/InitialCmplianceInspCreation.flow-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>61.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
     <customErrors>
         <name>Error</name>
         <label>Error</label>
@@ -40,7 +41,7 @@
             <label>Available</label>
         </rules>
     </decisions>
-    <description>ALR-1027 V8 update to status closed</description>
+    <description>BCMOHAD-29533 V4 - Updated the flow run criteria to prevent duplicate records.</description>
     <environments>Default</environments>
     <formulas>
         <name>Datefield</name>
@@ -175,6 +176,7 @@
         <connector>
             <targetReference>AscLocationData</targetReference>
         </connector>
+        <doesRequireRecordChangedToMeetCriteria>true</doesRequireRecordChangedToMeetCriteria>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Status</field>


### PR DESCRIPTION
changed the flow run option from
 “Every time a record is updated and meets the condition requirements”  to “Only when a record is updated to meet the condition requirements”  to prevent and avoid creating duplicate records.