### PR TITLE
[EHIS-2240]: Update drinking water operating permit template for trea…

### DIFF
--- a/bcgov-source/app-alr/main/default/omniDataTransforms/TransformDrinkingWaterSystemPermitTemplate_1.rpt-meta.xml
+++ b/bcgov-source/app-alr/main/default/omniDataTransforms/TransformDrinkingWaterSystemPermitTemplate_1.rpt-meta.xml
@@ -1,0 +1,1014 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OmniDataTransform xmlns="http://soap.sforce.com/2006/04/metadata">
+    <active>false</active>
+    <assignmentRulesUsed>false</assignmentRulesUsed>
+    <deletedOnSuccess>false</deletedOnSuccess>
+    <errorIgnored>false</errorIgnored>
+    <fieldLevelSecurityEnabled>false</fieldLevelSecurityEnabled>
+    <inputType>JSON</inputType>
+    <isManagedUsingStdDesigner>false</isManagedUsingStdDesigner>
+    <name>TransformDrinkingWaterSystemPermitTemplate</name>
+    <nullInputsIncludedInOutput>false</nullInputsIncludedInOutput>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6875</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumOocysts</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumOocysts</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom1938</globalKey>
+        <inputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:WaterSuppliersDWSWellTagNumber</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:WaterSuppliersDWSWellTagNumber</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom442</globalKey>
+        <inputFieldName>BLAccountPhysicalAddress</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountPhysicalAddress</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom4628</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTOtherTreatmentMethod</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTOtherTreatmentMethod</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7687</globalKey>
+        <inputFieldName>AccountCategoryL3</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>AccountCategoryL3</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom969</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountDWSName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountDWSName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom583</globalKey>
+        <inputFieldName>BLAccountNonPotableWaterSystem</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountNonPotableWaterSystem</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>ad79acfe-cbcc-4fd5-8588-ca5d5673c95c</globalKey>
+        <inputFieldName>BLAccountDWS:FacilitiesDWTDetails:FacilityCatL1DWTTreatmentMethodType</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWS:FacilitiesDWTDetails:FacilityCatL1DWTTreatmentMethodType</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7618</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDPhysicalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDPhysicalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5248</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTTreatmentMethod</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTTreatmentMethod</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>490a1cb2-03d1-48cb-96b3-1f7c7910f5a7</globalKey>
+        <inputFieldName>BLAccountPhysicalAddressCity</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountPhysicalAddressCity</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6427</globalKey>
+        <inputFieldName>BLAccountName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom854</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDMetalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDMetalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6057</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherChemicalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherChemicalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom3161</globalKey>
+        <inputFieldName>BLIdentifier</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLIdentifier</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom9690</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWSDetails:FacilityCatL1DWSBLAccountName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWSDetails:FacilityCatL1DWSBLAccountName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6393</globalKey>
+        <inputFieldName>AccountCategoryL1</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>AccountCategoryL1</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom943</globalKey>
+        <inputFieldName>BLAccountNoofConnections</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountNoofConnections</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom4404</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>cdde1e83-4398-43d7-a61b-972741926d79</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:VirusCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:VirusCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom4593</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDRadiologicalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDRadiologicalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom43</globalKey>
+        <inputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountMaximumDesignFlowRateM3PerDay</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountMaximumDesignFlowRateM3PerDay</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5897</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDSecondaryDisinfectionRequired</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDSecondaryDisinfectionRequired</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>15311cf6-689a-43dc-a10a-7e44a304d8c3</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:TreatmentMethod</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:TreatmentMethod</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>0425351f-9b49-49e4-b97d-2d4f46fbc8b9</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:CryptosporidiumCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:CryptosporidiumCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom9393</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTVirusCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTVirusCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5250</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>ac13181f-9533-431c-9d50-2e15085b0b4e</globalKey>
+        <inputFieldName>BLAccountFacilityHAName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountFacilityHAName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>d4c75bbb-2345-4bcf-bc3c-92105cded81d</globalKey>
+        <inputFieldName>BLAccountWaterSourceCategory</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountWaterSourceCategory</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom9614</globalKey>
+        <inputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountDWSName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountDWSName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom1423</globalKey>
+        <inputFieldName>BLAccountServiceAreaDescription</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountServiceAreaDescription</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>0cef8c01-1a6f-42a1-8cef-9844ddb9019c</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:TreatmentMethodType</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:TreatmentMethodType</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6369</globalKey>
+        <inputFieldName>BLAccountPHOWaterSourceCategory</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountPHOWaterSourceCategory</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom8496</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDPesticidesParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDPesticidesParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom596</globalKey>
+        <inputFieldName>DocumentChecklistItemsERCPStatus</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>DocumentChecklistItemsERCPStatus</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom4043</globalKey>
+        <inputFieldName>BLIdentifier</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLIdentifier</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7378</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherMetalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherMetalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom8386</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTVirusCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTVirusCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5678</globalKey>
+        <inputFieldName>BLAOwnerName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAOwnerName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7032</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDChemicalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDChemicalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom3207</globalKey>
+        <inputFieldName>BLAccountOperatingMonths</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountOperatingMonths</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>324683af-7c0d-4777-a798-999bfc815b28</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:OtherTreatmentMethod</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:OtherTreatmentMethod</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>fea1c3f8-5569-4711-8b41-427213dfd9e7</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5604</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTCryptosporidiumCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom336</globalKey>
+        <inputFieldName>BLOrganizationAccountName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLOrganizationAccountName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom1570</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountDWSName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountDWSName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7364</globalKey>
+        <inputFieldName>BLAccountPHOWaterSystemSizeCategory</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountPHOWaterSystemSizeCategory</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom1247</globalKey>
+        <inputFieldName>BLAccountHealthAuthority</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountHealthAuthority</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom2759</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWSDetails:FacilityCatL1DWSStorageFacilityVolume</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWSDetails:FacilityCatL1DWSStorageFacilityVolume</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom2069</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherPhysicalParameters</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilitiesCatL1DWDOtherPhysicalParameters</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom3032</globalKey>
+        <inputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountDWSCategoryL1</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:BLAccountDWSCategoryL1</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom1902</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDBLAccountName</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDBLAccountName</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom8663</globalKey>
+        <inputFieldName>BLAccountNumber</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountNumber</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>e0e6754f-2226-4adb-a5cc-f5e11a38c308</globalKey>
+        <inputFieldName>BLPeriodStart</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLPeriodStart</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom4151</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCysts</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTGiardiaCysts</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>d2ac3a67-2096-450c-a75b-7efecbad7337</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:GiardiaCredits</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:AssetDetails:GiardiaCredits</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom6818</globalKey>
+        <inputFieldName>AccountCategoryL2</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>AccountCategoryL2</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <transformValuesMappings>{ }</transformValuesMappings>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5385</globalKey>
+        <inputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:WaterSuppliersDWSWaterLicenseNumber</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:WaterSuppliersDWSDetails:WaterSuppliersDWSWaterLicenseNumber</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom9522</globalKey>
+        <inputFieldName>BLOrganizationBillingAddress</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLOrganizationBillingAddress</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom7359</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDMinSamplingRequirement</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWDDetails:FacilityCatL1DWDMinSamplingRequirement</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom2227</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTViruses</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:FacilityCatL1DWTViruses</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5025</globalKey>
+        <inputFieldName>BLAccountPopulationServedper24hrs</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountPopulationServedper24hrs</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <omniDataTransformItem>
+        <disabled>false</disabled>
+        <filterGroup>0.0</filterGroup>
+        <globalKey>TransformDrinkingWaterSystemPermitTemplateCustom5497</globalKey>
+        <inputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountPhysicalAddress</inputFieldName>
+        <inputObjectQuerySequence>0.0</inputObjectQuerySequence>
+        <linkedObjectSequence>0.0</linkedObjectSequence>
+        <name>TransformDrinkingWaterSystemPermitTemplate</name>
+        <outputCreationSequence>1.0</outputCreationSequence>
+        <outputFieldName>BLAccountDWSDetails:FacilitiesDWTDetails:BLAccountPhysicalAddress</outputFieldName>
+        <outputObjectName>json</outputObjectName>
+        <requiredForUpsert>false</requiredForUpsert>
+        <upsertKey>false</upsertKey>
+    </omniDataTransformItem>
+    <outputType>JSON</outputType>
+    <previewJsonData>{
+  &quot;isWSICatL1SurfaceWater&quot; : false,
+  &quot;BLOrganizationBillingStreet&quot; : &quot;442 Watfield Avenue&quot;,
+  &quot;BLAccountWaterSourceIntakeSourceWaterBody&quot; : &quot;Well&quot;,
+  &quot;BLAccountDWSDetails&quot; : {
+    &quot;WaterSuppliersDWSDetails&quot; : [ {
+      &quot;BLAccountDWSName&quot; : &quot;test drinking water system&quot;,
+      &quot;WaterSuppliersDWSWaterLicenseNumber&quot; : &quot;1&quot;,
+      &quot;BLAccountDWSCategoryL1&quot; : &quot;Community Water System&quot;
+    }, {
+      &quot;BLAccountDWSName&quot; : &quot;test drinking water system&quot;,
+      &quot;WaterSuppliersDWSWaterLicenseNumber&quot; : &quot;2&quot;,
+      &quot;BLAccountDWSCategoryL1&quot; : &quot;Community Water System&quot;
+    }, {
+      &quot;BLAccountDWSName&quot; : &quot;test drinking water system&quot;,
+      &quot;WaterSuppliersDWSWaterLicenseNumber&quot; : &quot;3&quot;,
+      &quot;BLAccountDWSCategoryL1&quot; : &quot;Community Water System&quot;
+    } ],
+    &quot;FacilitiesDWTDetails&quot; : {
+      &quot;BLAccountDWSName&quot; : &quot;test drinking water system&quot;,
+      &quot;BLAccountPhysicalAddress&quot; : &quot;    &quot;
+    }
+  },
+  &quot;BLPeriodStart&quot; : &quot;2025-04-16T19:00:00.000Z&quot;,
+  &quot;BLOrganizationBillingCity&quot; : &quot;Nanaimo&quot;,
+  &quot;WaterSuppliers&quot; : {
+    &quot;WaterSuppliersName&quot; : &quot;Bullk Water&quot;
+  },
+  &quot;BLADetails&quot; : {
+    &quot;BLAName&quot; : &quot;BLA-0000001194&quot;
+  },
+  &quot;BLAOwnerName&quot; : &quot;Rahul Patle&quot;,
+  &quot;isWSICatL1GroundWater&quot; : false,
+  &quot;BLOrganizationBillingCountry&quot; : &quot;Canada&quot;,
+  &quot;BLAccountId&quot; : &quot;FA-00411&quot;,
+  &quot;RegulatoryAuthorizationTypeName&quot; : &quot;Drinking Water Construction Permit&quot;,
+  &quot;BLAccountWaterSourceIntakeCategoryL1&quot; : &quot;Bulkwater&quot;,
+  &quot;BLAccountName&quot; : &quot;test drinking water system&quot;,
+  &quot;BLAApplicantMailingAddress&quot; : &quot;Street 101 CA   &quot;,
+  &quot;BLOrganizationBillingPostalCode&quot; : &quot;V9R 3P7&quot;,
+  &quot;CurrentDate&quot; : &quot;2025-05-04&quot;,
+  &quot;BLIdentifier&quot; : &quot;2025-0000000017&quot;,
+  &quot;BLOrganizationId&quot; : &quot;001bZ0000083YqDQAU&quot;,
+  &quot;ConstructionPermitDocumentTemplateId&quot; : &quot;2dtbZ00000013ALQAY&quot;,
+  &quot;BLAccountRelatedWaterSourceIntakeWaterLicenseNumber&quot; : &quot;2&quot;,
+  &quot;ConstructionPermitDocumentTemplateName&quot; : &quot;ConstructionPermitforWaterSupplySystem&quot;,
+  &quot;AccountCategoryL3&quot; : &quot;Municipality&quot;,
+  &quot;BLAccountPhysicalAddress&quot; : &quot;    &quot;,
+  &quot;AccountCategoryL2&quot; : &quot;Local Gov System&quot;,
+  &quot;AccountCategoryL1&quot; : &quot;Community Water System&quot;,
+  &quot;BLAccountBillingAddress&quot; : &quot;test ACc Billing add Montreal  434333 &quot;,
+  &quot;DocumentChecklistItems&quot; : [ {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentDate&quot; : &quot;2025-04-28&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;2. Manufacturer’s Technical Specifications&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;1. Cover Letter&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;10. Additional Plans&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;7. Engineered Plans&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;6. Basic Plans iii. Schematic Diagram(s)&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;9. Distribution System Map&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;11. Process Schematic Diagram&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;8. Source Approval&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;3. Design Brief&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;5. Basic Plans ii. Site Plan&quot;
+  }, {
+    &quot;FileUploadDate&quot; : &quot;2025-04-28T13:28:38.000Z&quot;,
+    &quot;DocumentChecklistItemsName&quot; : &quot;4. Basic Plans i. Location Map&quot;
+  } ],
+  &quot;BLOrganizationAccountName&quot; : &quot;Sophie&apos;s Inc.&quot;,
+  &quot;BLOrganizationBillingState&quot; : &quot;BC&quot;,
+  &quot;BLAApplicantName&quot; : &quot;test  rp rp&quot;,
+  &quot;BLAccountPHOWaterSourceCategory&quot; : &quot;Small Water System &lt;50&quot;,
+  &quot;BLAccountPHOWaterSystemSizeCategory&quot; : &quot;Small Water System &lt;50&quot;,
+  &quot;BLOrganizationName&quot; : &quot;Sophie&apos;s Inc.&quot;
+}</previewJsonData>
+    <processSuperBulk>false</processSuperBulk>
+    <responseCacheTtlMinutes>0.0</responseCacheTtlMinutes>
+    <rollbackOnError>false</rollbackOnError>
+    <sourceObject>json</sourceObject>
+    <sourceObjectDefault>false</sourceObjectDefault>
+    <synchronousProcessThreshold>0.0</synchronousProcessThreshold>
+    <targetOutputFileName>DrinkingWaterSystemOperatingPermitTemplate(Version 1)</targetOutputFileName>
+    <type>Transform</type>
+    <uniqueName>TransformDrinkingWaterSystemPermitTemplate_1</uniqueName>
+    <versionNumber>1.0</versionNumber>
+    <xmlDeclarationRemoved>false</xmlDeclarationRemoved>
+</OmniDataTransform>


### PR DESCRIPTION
		AC #1:
		PHOCS Drinking Water Operating Permit Template is updated so that the Pathogen Log 
		Reduction Credits Assigned table logic is updated to pull the Treatment Method 
		Asset record tied to the Treatment Facility through the Account field on the Asset 
		record rather than the Water Treatment Facility field. User is able to see the treatment 
		method information from the asset records linked to a treatment facility populated in 
		the Operating Permit document as per 
		PHOCS Drinking Water Operating Permit Template_V0.2.docx.