### PR TITLE
BCMOHAD-31370 || Redundant metadata

### DIFF
--- a/.github/workflows/HFOpsQA Code Deployment.yml
+++ b/.github/workflows/HFOpsQA Code Deployment.yml
@@ -1,4 +1,4 @@
-name: OpsQA Code Deployment
+name: HFOpsQA Code Deployment
 
 # Definition when the workflow should run
 on:
@@ -17,7 +17,7 @@ on:
 jobs:
   Code-Deploy-Run:
     runs-on: ubuntu-24.04
-    environment: OpsQA
+    environment: HFOpsQA
     env:
         SFDXAUTHURL: ${{ secrets.SFDXAUTHURL }}
     steps:
@@ -40,11 +40,11 @@ jobs:
       - name: 'Authenticate Sandbox'
         run: |
             echo "${{ env.SFDXAUTHURL }}" > ./authfile
-            sf org login sfdx-url -f authfile -a OpsQA
+            sf org login sfdx-url -f authfile -a HFOpsQA
 
       # deploy code without running test classes
       - name: 'Deploy source code'
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --testlevel RunLocalTests --targetusername OpsQA
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose -g --testlevel RunLocalTests --targetusername HFOpsQA
 
   Git-Tag-Run:
     needs: Code-Deploy-Run
@@ -59,15 +59,15 @@ jobs:
 
       - name: 'Get latest tag'
         id: latesttag
-        run: echo "LATEST_TAG=$(git describe --tags --match "OpsQA*" --abbrev=0 HEAD)" >> $GITHUB_OUTPUT
+        run: echo "LATEST_TAG=$(git describe --tags --match "HFOpsQA*" --abbrev=0 HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Increment Tag'
         id: newtag
         run: |
           LATEST_TAG=${{ steps.latesttag.outputs.LATEST_TAG }}
-          NUMBER=${LATEST_TAG#OpsQA.}
+          NUMBER=${LATEST_TAG#HFOpsQA.}
           NEW_NUMBER=$((NUMBER + 1))
-          NEW_TAG=OpsQA.${NEW_NUMBER}
+          NEW_TAG=HFOpsQA.${NEW_NUMBER}
           echo "NEW_TAG=$NEW_TAG" >> $GITHUB_OUTPUT
 
       - name: 'Push new tag'

--- a/.github/workflows/PR_Code_Deployment_Hotfix.yml
+++ b/.github/workflows/PR_Code_Deployment_Hotfix.yml
@@ -16,8 +16,8 @@ on:
 # Jobs to be executed
 jobs:
   Code-Deploy-Run:
-    runs-on: ubuntu-24.04
-    environment: HOTFIXCI
+    runs-on: ubuntu-latest
+    environment: HFOpsCI
     env:
       SFDXAUTHURL: ${{ secrets.SFDXAUTHURL }}
     steps:
@@ -37,8 +37,8 @@ jobs:
       - name: 'Authenticate Sandbox'
         run: |
             echo "${{ env.SFDXAUTHURL }}" > ./authfile
-            sf org login sfdx-url -f authfile -a HOTFIXCI
+            sf org login sfdx-url -f authfile -a HFOpsCI
 
       # deploy code without running test classes
       - name: 'Deploy source code'
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 -g --targetusername HOTFIXCI
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 -g --targetusername HFOpsCI

--- a/.github/workflows/PR_Code_Deployment_Hotfix.yml
+++ b/.github/workflows/PR_Code_Deployment_Hotfix.yml
@@ -41,4 +41,4 @@ jobs:
 
       # deploy code without running test classes
       - name: 'Deploy source code'
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --targetusername HOTFIXCI
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 -g --targetusername HOTFIXCI

--- a/.github/workflows/PR_Code_Validation_Hotfix.yml
+++ b/.github/workflows/PR_Code_Validation_Hotfix.yml
@@ -87,4 +87,5 @@ jobs:
 
       - name: Validate Code
         id: run_code_validation
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HFOPSCI
+        run: sf project deploy start --source-dir bcgov-source/app-phocs/main/default --source-dir bcgov-source/core/main/default --source-dir bcgov-source/app-alr/main/default --wait 60 --dry-run --test-level RunLocalTests -g --target-org HFOPSCI
+       # run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HFOPSCI

--- a/.github/workflows/PR_Code_Validation_Hotfix.yml
+++ b/.github/workflows/PR_Code_Validation_Hotfix.yml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Validate Code
         id: run_code_validation
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests --targetusername HOTFIXCI
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HOTFIXCI

--- a/.github/workflows/PR_Code_Validation_Hotfix.yml
+++ b/.github/workflows/PR_Code_Validation_Hotfix.yml
@@ -82,9 +82,9 @@ jobs:
       # Authenticate HFOpsCI sandbox
       - name: 'Authenticate HFOpsCI Sandbox'
         run: |
-            echo "${{ secrets.HFOpsCI_SFDXAUTHURL }}" > ./authfile
-            sf org login sfdx-url -f authfile -a HFOpsCI
+            echo "${{ secrets.HFOPSCI_SFDXAUTHURL }}" > ./authfile
+            sf org login sfdx-url -f authfile -a HFOPSCI
 
       - name: Validate Code
         id: run_code_validation
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HFOpsCI
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HFOPSCI

--- a/.github/workflows/PR_Code_Validation_Hotfix.yml
+++ b/.github/workflows/PR_Code_Validation_Hotfix.yml
@@ -79,12 +79,12 @@ jobs:
         id: lint_tests
         run: sfdx scanner:run --engine eslint-lwc --target "${{ vars.RELEASE_PIPELINE_SOURCEPATH }}"
 
-      # Authenticate HOTFIXCI sandbox
-      - name: 'Authenticate HOTFIXCI Sandbox'
+      # Authenticate HFOpsCI sandbox
+      - name: 'Authenticate HFOpsCI Sandbox'
         run: |
-            echo "${{ secrets.HOTFIXCI_SFDXAUTHURL }}" > ./authfile
-            sf org login sfdx-url -f authfile -a HOTFIXCI
+            echo "${{ secrets.HFOpsCI_SFDXAUTHURL }}" > ./authfile
+            sf org login sfdx-url -f authfile -a HFOpsCI
 
       - name: Validate Code
         id: run_code_validation
-        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HOTFIXCI
+        run: sfdx force:source:deploy --sourcepath ${{ vars.RELEASE_PIPELINE_SOURCEPATH }} --wait 60 --verbose --checkonly --testlevel RunLocalTests -g --targetusername HFOpsCI

--- a/bcgov-source/app-alr/main/default/classes/MassEmailControllerTest.cls
+++ b/bcgov-source/app-alr/main/default/classes/MassEmailControllerTest.cls
@@ -18,7 +18,7 @@ public class MassEmailControllerTest {
 		Contact contRec = TestDataFactory.createContactRecord(residenceRec1.Id, 'test1@xyz.com', 'firstname1', 'lastname1', true);
         
         AccountContactRelation acConRelRec = TestDataFactory.createAccContRelRecord(residenceRec1.Id, contactRec.Id , true, true, true);
-        AccountContactRelation acConRelRec1 = TestDataFactory.createAccContRelRecord(residenceRec2.Id, contRec.Id , false, true, true);
+
         Asset unitRec1 = TestDataFactory.createUnit('1', 'Private', 2, residenceRec1.Id, true);
         unitRec1.recordTypeId = parentAssetRTId;
         //unit1.GenerateInvoice__c = true;
@@ -28,11 +28,7 @@ public class MassEmailControllerTest {
         blaRec.AccountId=residenceRec1.Id;
         update blaRec;
         BusinessLicense blRec = TestDataFactory.createBlRecord(regAuth.Id, residenceRec1.Id, residenceRec1.ParentId, '58659', 'BL RECORD 1', true);
-        BusinessLicenseApplication blaRec1 = TestDataFactory.createRenewalBla(residenceRec2.LicenseType__c, residenceRec2.Id, true);
-        blaRec1.Late_Fee_Status__c='Ready to Send';
-        blaRec1.AccountId=residenceRec2.Id;
-        update blaRec1;
-        BusinessLicense blRec1 = TestDataFactory.createBlRecord(regAuth.Id, residenceRec2.Id, residenceRec2.ParentId, '58459', 'BL RECORD 2', true);
+        
         ContentVersion contentVersionRec = TestDataFactory.createContentVer('title value 1', blaRec.Id, true);
         //ContentVersion contentVersionRec1 = TestDataFactory.createContentVer('title value 2', blaRec.Id, true);
       
@@ -48,29 +44,6 @@ public class MassEmailControllerTest {
         Test.stopTest();
         List<Account> accRec = [SELECT Id FROM Account];
         Assert.isNotNull(accRec.size());
-    }
-
-    @isTest
-    static void testnoprimarycontact() {
-        // Use testSetup data: find the residence account created there
-        Account acct = [SELECT Id FROM Account WHERE Name = 'Account2' LIMIT 1];
-        // Remove any AccountContactRelation to simulate no primary contact
-        List<AccountContactRelation> acrs = [SELECT Id, IsActive FROM AccountContactRelation WHERE AccountId = :acct.Id];
-        if (!acrs.isEmpty()) {
-            for (AccountContactRelation a : acrs) {
-                a.IsActive = false;
-            }
-            update acrs;
-        }
-
-        BusinessLicenseApplication bla = [SELECT Id FROM BusinessLicenseApplication WHERE AccountId = :acct.Id LIMIT 1];
-
-        Test.startTest();
-        MassEmailController.doSendRenewals();
-        Test.stopTest();
-
-        System.assert(MassEmailController.blaErrMap.containsKey(bla.Id), 'Expected no-primary-contact error for BLA');
-        System.assert(MassEmailController.blaErrMap.get(bla.Id).contains(BCMOH_Constants.noPrimaryContact));
     }
     //test method-ALR-1000
      @isTest
@@ -106,7 +79,7 @@ public class MassEmailControllerTest {
     //updateBlaRecs exception
      @isTest
     static void updateBlaRecsTest1() {
-        BusinessLicenseApplication blaRec = [SELECT Id, Status, ExclusionReason__c FROM BusinessLicenseApplication LIMIT 1];
+        BusinessLicenseApplication blaRec = [SELECT Id, Status, ExclusionReason__c FROM BusinessLicenseApplication];
         blaRec.ExclusionReason__c = 'testing';
         Object data = blaRec;
         Test.startTest();

--- a/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/AccountId.field-meta.xml
+++ b/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/AccountId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>AccountId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/Email.field-meta.xml
+++ b/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/Email.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Email</fullName>
-    <encryptionScheme>None</encryptionScheme>
-    <trackHistory>true</trackHistory>
-</CustomField>

--- a/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/OwnerId.field-meta.xml
+++ b/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/OwnerId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>OwnerId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/Priority.field-meta.xml
+++ b/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/Priority.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Priority</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Picklist</type>
-</CustomField>

--- a/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/ResolutionPriority.field-meta.xml
+++ b/bcgov-source/app-alr/main/default/objects/PublicComplaint/fields/ResolutionPriority.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>ResolutionPriority</fullName>
-    <trackHistory>true</trackHistory>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/BusinessLicense/fields/AccountId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/BusinessLicense/fields/AccountId.field-meta.xml
@@ -1,20 +1,12 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>AccountId</fullName>
     <lookupFilter>
         <active>true</active>
-        <booleanFilter>1 OR 2</booleanFilter>
-        <errorMessage>Please select Residence.</errorMessage>
         <filterItems>
             <field>Account.RecordTypeId</field>
             <operation>equals</operation>
-            <value>Residence</value>
-        </filterItems>
-        <filterItems>
-            <field>Account.RecordTypeId</field>
-            <operation>equals</operation>
-            <value>PHOCS Drinking Water Source Intake, PHOCS Drinking Water System, PHOCS Facility, PHOCS Dairy Facility</value>
+            <value>Registrant, PHOCS Business Entity</value>
         </filterItems>
         <isOptional>false</isOptional>
     </lookupFilter>

--- a/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/IsRequired.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/IsRequired.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>IsRequired</fullName>
-    <trackHistory>true</trackHistory>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/Name.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/Name.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Name</fullName>
-    <trackHistory>true</trackHistory>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/OwnerId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/OwnerId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>OwnerId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/ParentRecordId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/ParentRecordId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>ParentRecordId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/WhoId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/DocumentChecklistItem/fields/WhoId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>WhoId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/AccountId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/AccountId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>AccountId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/DueDate.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/DueDate.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>DueDate</fullName>
-    <trackHistory>true</trackHistory>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/ParentRecordId.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/ParentRecordId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>ParentRecordId</fullName>
-    <trackHistory>true</trackHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/TotalFeeAmount.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/RegulatoryTrxnFee/fields/TotalFeeAmount.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>TotalFeeAmount</fullName>
-    <trackHistory>true</trackHistory>
-</CustomField>


### PR DESCRIPTION
-Remove redundant metadata on hotfixdev branch (extra fields on RegulatoryTrxnFee, DocumentChecklistItem) 
RegulatoryTrxnFee:TotalFeeAmount,ParentRecordID,DueDate,AccountID
DocumentChecklistItem: WhoID, OwnerID, ParentRecordID, Name, IsRequired

These fields do exist only on hotifxdev branch, they are not present on dev and Release branch release-phocs-prod-18.1.0. Confirmed with the project team 

-Updating YAML Scripts 