### PR TITLE
EHIS-3098 Components

### DIFF
--- a/bcgov-source/app-phocs/main/default/flexipages/FacilityRecordPage.flexipage-meta.xml
+++ b/bcgov-source/app-phocs/main/default/flexipages/FacilityRecordPage.flexipage-meta.xml
@@ -755,6 +755,29 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.HasAContractWithHealthAuthority__c</fieldItem>
+                <identifier>RecordHasAContractWithHealthAuthority__cField</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 OR 2</booleanFilter>
+                    <criteria>
+                        <leftValue>{!Record.Type}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Child Care</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.Type}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Residential Care</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.CCIMSID__c</fieldItem>
                 <identifier>RecordCCIMSID_cField</identifier>
                 <visibilityRule>

--- a/bcgov-source/app-phocs/main/default/permissionsets/EHISCreateEditFacilities.permissionset-meta.xml
+++ b/bcgov-source/app-phocs/main/default/permissionsets/EHISCreateEditFacilities.permissionset-meta.xml
@@ -547,6 +547,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.HasAContractWithHealthAuthority__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Account.HealthAuthority__c</field>
         <readable>true</readable>

--- a/bcgov-source/app-phocs/main/default/permissionsets/EHIS_Manage_System_Admin_User_PS.permissionset-meta.xml
+++ b/bcgov-source/app-phocs/main/default/permissionsets/EHIS_Manage_System_Admin_User_PS.permissionset-meta.xml
@@ -650,6 +650,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.HasAContractWithHealthAuthority__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Account.HealthAuthority__c</field>
         <readable>true</readable>

--- a/bcgov-source/app-phocs/main/default/permissionsets/PHOCSReportingUserGroupMembershipPS.permissionset-meta.xml
+++ b/bcgov-source/app-phocs/main/default/permissionsets/PHOCSReportingUserGroupMembershipPS.permissionset-meta.xml
@@ -3,6 +3,11 @@
     <description>Enables Household and Group features in the org.</description>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Account.HasAContractWithHealthAuthority__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>AccountAccountRelation.IsActive</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/bcgov-source/core/main/default/objects/Account/fields/HasAContractWithHealthAuthority__c.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/Account/fields/HasAContractWithHealthAuthority__c.field-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasAContractWithHealthAuthority__c</fullName>
+    <description>EHIS-3098</description>
+    <label>Has a Contract with Health Authority?</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Yes</fullName>
+                <default>false</default>
+                <label>Yes</label>
+            </value>
+            <value>
+                <fullName>No</fullName>
+                <default>false</default>
+                <label>No</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>


### PR DESCRIPTION
Changes to implement EHIS-3098 - Capture HA Contract information on Residential Care/Child Care facilities

Components: 

New CustomField:
-HasAContractWithHealthAuthority__c

Lightning Record Page:  New field is added to the LRP
 -FacilityRecordPage

Permission Sets: FLS provided to the new field the these permsets.
  Read/Write:
  - EHISCreateEditFacilities
  - EHIS_Manage_System_Admin_User_PS
  Read:
  - PHOCSReportingUserGroupMembershipPS
