### PR TITLE
[EHIS-3766] Reverting changes done in Resdence RecordTypes - Keep all values

### DIFF
--- a/bcgov-source/core/main/default/objects/Account/recordTypes/Residence.recordType-meta.xml
+++ b/bcgov-source/core/main/default/objects/Account/recordTypes/Residence.recordType-meta.xml
@@ -49,7 +49,11 @@
         </values>
     </picklistValues>
     <picklistValues>
-<picklist>Status__c</picklist>       
+<picklist>Status__c</picklist>
+        <values>
+            <fullName>Application in Progress</fullName>
+            <default>false</default>
+        </values>
         <values>
             <fullName>Appeal Complete%3A dismissed</fullName>
             <default>false</default>
@@ -89,7 +93,103 @@
         <values>
             <fullName>Temporarily Closed</fullName>
             <default>false</default>
-        </values>        
+        </values>
+        <values>
+            <fullName>Refused Application/Registation</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>PURR Application in Progress</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>CURR Application in Progress</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Application closed</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Application withdrawn</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Registered Active</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Registered Active with Conditions</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Registered Active Registrant change</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Registered Active Pending Renewal</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Registered Active Progressive Enforcement</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Unregistered Active Pending Renewal</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Cancelled</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Suspended</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Deregistered Owner Change</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Deregistered Location Change</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Deregistered Withdrawn</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>PURR</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>CURR Not in Compliance</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>CURR In Compliance</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>CURR SIU Referral</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Not AL Licensed</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Not AL Personal Dwelling</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Not AL Independent Living</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>Not AL Sober Living or Supportive Housing</fullName>
+            <default>false</default>
+        </values>
     </picklistValues>
     <picklistValues>
         <picklist>ClassType__c</picklist>


### PR DESCRIPTION
Reverting changes done in Residence Record Types - The values mentioned in EHIS-3333 and EHIS-2949 are not the complete list , instead it was an updated list.  Wrongly removed all the values and kept only the values mentioned in these stories. 

Reverting now, so that all values will be visible. 

<img width="997" height="615" alt="image" src="https://github.com/user-attachments/assets/189ce845-9ffb-4bb5-b9fa-2c479dad0738" />
