### PR TITLE
Fixing bug EHIS-4085 - LRP and Custom Fields

### DIFF
--- a/bcgov-source/app-phocs/main/default/flexipages/BLAOperatingPermitRecordPage.flexipage-meta.xml
+++ b/bcgov-source/app-phocs/main/default/flexipages/BLAOperatingPermitRecordPage.flexipage-meta.xml
@@ -635,6 +635,29 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.ExpectedAttendance__c</fieldItem>
                 <identifier>RecordExpectedAttendance_cField</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 AND ( 2 OR 3 OR 4)</booleanFilter>
+                    <criteria>
+                        <leftValue>{!Record.LicenseType.Name}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Temporary Food Service Permit</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.ValidMobilePermit__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Yes</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.ValidMobilePermit__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>No</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.ValidMobilePermit__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Yes, but different mobile/have ancillary set up</rightValue>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>

--- a/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/FoodSafeLevel1Certification__c.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/FoodSafeLevel1Certification__c.field-meta.xml
@@ -3,6 +3,7 @@
     <fullName>FoodSafeLevel1Certification__c</fullName>
     <defaultValue>false</defaultValue>
     <description>EHIS-3132</description>
+    <inlineHelpText>One person on-site will have a valid FOODSAFE Level 1 (or equivalent) certification</inlineHelpText>
     <label>FOODSAFE Level 1 Certification</label>
     <trackHistory>false</trackHistory>
     <type>Checkbox</type>

--- a/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/OnSiteFoodPrepStoragePremise__c.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/OnSiteFoodPrepStoragePremise__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OnSiteFoodPrepStoragePremise__c</fullName>
     <description>EHIS-3132</description>
+    <inlineHelpText>What type of premises will be used to prepare and/or store food at the site of the event?</inlineHelpText>
     <label>On-site Food Prep/Storage Premise</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/ValidMobilePermit__c.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/BusinessLicenseApplication/fields/ValidMobilePermit__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ValidMobilePermit__c</fullName>
     <description>EHIS-3132</description>
+    <inlineHelpText>Do you have a Mobile Permit to Operate in BC?</inlineHelpText>
     <label>Valid Mobile Permit?</label>
     <required>false</required>
     <trackHistory>false</trackHistory>


### PR DESCRIPTION

Changes: 

1- Dynamic Visibility added for one field in BLA-Operating Permit Record Page
 Expected Attendance field is enabled always instead of Logic: if Valid Mobile Permit? = No or Yes, but different mobile/have ancillary set up

2-  Help text is added for the below fields

Field label: FOODSAFE Level 1 Certification
Field label: On-site Food Prep/Storage Premise
Field label: Valid Mobile Permit? 