### PR TITLE
EHIS-3375 [OWL Retention Rules ]

### DIFF
--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
@@ -1,0 +1,26 @@
+public class PHOCSExpireOWLRetentionBatch implements Database.Batchable<SObject> {
+
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        Date fiveYearsAgo = Date.today().addYears(-5);
+        return Database.getQueryLocator([
+            SELECT Id
+            FROM   Account
+            WHERE  OWLPublicRetentionActive__c   = true
+            AND    Status__c                     = 'Closed'
+            AND    OperationEndDate__c           <= :fiveYearsAgo
+        ]);
+    }
+
+    public void execute(Database.BatchableContext bc, List<Account> scope) {
+        
+        for (Account acc : scope) {
+    
+            acc.OWLPublicRetentionActive__c = false;
+        }      
+        update scope;     
+    }
+
+    public void finish(Database.BatchableContext bc) {
+       
+    }
+}

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
@@ -12,21 +12,10 @@ public class PHOCSExpireOWLRetentionBatch implements Database.Batchable<SObject>
     }
 
     public void execute(Database.BatchableContext bc, List<Account> scope) {
-        
         for (Account acc : scope) {
-          
             acc.OWLPublicRetentionActive__c = false;
         }
-        Database.SaveResult[] results = Database.update(scope,false);
-        
-        for (Integer i=0; i<results.size(); i++){
-            if (!results[i].isSuccess()){
-                for (Database.Error err : results[i].getErrors()){
-                    System.debug ('Record id: ' + scope[i].id);
-                    System.debug ('Error: ' + err.getMessage());
-                }
-            }
-        }
+        Database.SaveResult[] results = Database.update(scope, false);
     }
 
     public void finish(Database.BatchableContext bc) {

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls
@@ -14,13 +14,22 @@ public class PHOCSExpireOWLRetentionBatch implements Database.Batchable<SObject>
     public void execute(Database.BatchableContext bc, List<Account> scope) {
         
         for (Account acc : scope) {
-    
+          
             acc.OWLPublicRetentionActive__c = false;
-        }      
-        update scope;     
+        }
+        Database.SaveResult[] results = Database.update(scope,false);
+        
+        for (Integer i=0; i<results.size(); i++){
+            if (!results[i].isSuccess()){
+                for (Database.Error err : results[i].getErrors()){
+                    System.debug ('Record id: ' + scope[i].id);
+                    System.debug ('Error: ' + err.getMessage());
+                }
+            }
+        }
     }
 
     public void finish(Database.BatchableContext bc) {
-       
+    
     }
 }

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls-meta.xml
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatchTest.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatchTest.cls
@@ -1,0 +1,72 @@
+@isTest(SeeAllData=false)
+private class PHOCSExpireOWLRetentionBatchTest {
+
+    static final Id FACILITY_RT_ID = Schema.SObjectType.Account.getRecordTypeInfosByDeveloperName().get('Facility').getRecordTypeId();
+
+    static Account buildAccount(String name, Boolean retentionActive, Date operationEndDate) {
+        Account acc = new Account(
+            Name                        = name,
+            RecordTypeId                = FACILITY_RT_ID,
+            Status__c                   = 'Closed',
+            OWLPublicRetentionActive__c = retentionActive,
+            OperationEndDate__c         = operationEndDate
+        );
+        insert acc;
+        return acc;
+    }
+
+    @isTest
+    static void testExpiresPastFiveYears() {
+        Account old = buildAccount('Old OWL Facility', true, Date.today().addYears(-6));
+        Test.startTest();
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+        Test.stopTest();
+
+        Account result = [SELECT OWLPublicRetentionActive__c FROM Account WHERE Id = :old.Id];
+        System.assertEquals(false, result.OWLPublicRetentionActive__c, 'Retention flag must be cleared for facilities past the 5-year window');
+    }
+
+    @isTest
+    static void testIgnoresWithinFiveYears() {
+        Account recent = buildAccount('Recent OWL Facility', true, Date.today().addYears(-3));
+        Test.startTest();
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+        Test.stopTest();
+
+        Account result = [SELECT OWLPublicRetentionActive__c FROM Account WHERE Id = :recent.Id];
+        System.assertEquals(true, result.OWLPublicRetentionActive__c, 'Retention flag must remain true for facilities still within the 5-year window');
+    }
+
+    @isTest
+    static void testIgnoresRetentionNotActive() {
+        Account nonOwl = buildAccount('Non OWL Facility', false, Date.today().addYears(-6));
+        Test.startTest();
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+        Test.stopTest();
+
+        Account result = [SELECT OWLPublicRetentionActive__c FROM Account WHERE Id = :nonOwl.Id];
+        System.assertEquals(false, result.OWLPublicRetentionActive__c, 'Facilities with retention not active must never be touched by the expiry batch');
+    }
+
+    @isTest
+    static void testExactFiveYearBoundary() {
+        Account boundary = buildAccount('Boundary OWL Facility', true, Date.today().addYears(-5));
+        Test.startTest();
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+        Test.stopTest();
+
+        Account result = [SELECT OWLPublicRetentionActive__c FROM Account WHERE Id = :boundary.Id];
+        System.assertEquals(false, result.OWLPublicRetentionActive__c, 'Retention flag must be cleared on the exact 5-year anniversary day with <= logic');
+    }
+
+    @isTest
+    static void testIgnoresAlreadyExpired() {
+        Account alreadyExpired = buildAccount('Already Expired OWL', false, Date.today().addYears(-6));
+        Test.startTest();
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+        Test.stopTest();
+
+        Account result = [SELECT OWLPublicRetentionActive__c FROM Account WHERE Id = :alreadyExpired.Id];
+        System.assertEquals(false, result.OWLPublicRetentionActive__c, 'Already-expired flag must remain false after batch runs');
+    }
+}

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatchTest.cls-meta.xml
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionBatchTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionScheduler.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionScheduler.cls
@@ -1,0 +1,5 @@
+public class PHOCSExpireOWLRetentionScheduler implements Schedulable {
+    public void execute(SchedulableContext sc) {
+        Database.executeBatch(new PHOCSExpireOWLRetentionBatch(), 200);
+    }
+}

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionScheduler.cls-meta.xml
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSExpireOWLRetentionScheduler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSPublicDisplayObjectRecords.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSPublicDisplayObjectRecords.cls
@@ -350,6 +350,16 @@ global without sharing class PHOCSPublicDisplayObjectRecords implements Callable
 			   returnQuery = addFlexCardFilters(filterItems,returnQuery);
                return returnQuery;
             }
+            when 'childcareowl'{
+               returnQuery = ' Where RecordType.DeveloperName=\'Facility\' AND Status__c = \'closed\' AND Type=\'Child Care\' AND OWLPublicRetentionActive__c = true';
+			   returnQuery = addFlexCardFilters(filterItems,returnQuery);
+               return returnQuery;
+            }
+            when 'residentialcareowl'{
+               returnQuery = ' Where RecordType.DeveloperName=\'Facility\' AND Status__c = \'closed\' AND Type=\'Residential Care\' AND OWLPublicRetentionActive__c = true';
+			   returnQuery = addFlexCardFilters(filterItems,returnQuery);
+               return returnQuery;
+            }
         }
         return '';
     }
@@ -380,7 +390,7 @@ global without sharing class PHOCSPublicDisplayObjectRecords implements Callable
         Object wrap(SObject record);
     }
 
-   public class AccountDetailsWrapper implements SObjectWrapper {
+    public class AccountDetailsWrapper implements SObjectWrapper {
         public Object wrap(SObject record) {
             Account accRecord = (Account) record;
             Map<String, Object> result = new Map<String, Object>{

--- a/bcgov-source/app-phocs/main/default/classes/PHOCSPublicDisplayObjectRecordsTest.cls
+++ b/bcgov-source/app-phocs/main/default/classes/PHOCSPublicDisplayObjectRecordsTest.cls
@@ -242,6 +242,15 @@ private class PHOCSPublicDisplayObjectRecordsTest {
         };
         runTestCallMethod('getFacilityList', input);
         
+        input = new Map<String, Object>{
+            'programArea' => 'childcareowl'
+        };
+        runTestCallMethod('getFacilityList', input);
+
+        input = new Map<String, Object>{
+            'programArea' => 'residentialcareowl'
+        };
+        runTestCallMethod('getFacilityList', input);
         
         input = new Map<String, Object>{
             'programArea' => ''

--- a/bcgov-source/app-phocs/main/default/flows/PHOCS_Account_SetOWLRetentionOnClosure.flow-meta.xml
+++ b/bcgov-source/app-phocs/main/default/flows/PHOCS_Account_SetOWLRetentionOnClosure.flow-meta.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
+    <assignments>
+        <name>Set_OWL_Retention_Fields</name>
+        <label>Set OWL Retention Fields</label>
+        <locationX>176</locationX>
+        <locationY>407</locationY>
+        <assignmentItems>
+            <assignToReference>$Record.OWLPublicRetentionActive__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>$Record.OperationEndDate__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Flow.CurrentDate</elementReference>
+            </value>
+        </assignmentItems>
+    </assignments>
+    <decisions>
+        <name>Is_Valid_OWL_Closure</name>
+        <label>Is Valid OWL Closure</label>
+        <locationX>176</locationX>
+        <locationY>287</locationY>
+        <defaultConnectorLabel>Not OWL Closure</defaultConnectorLabel>
+        <rules>
+            <name>Is_Child_Care_OWL</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.RecordType.DeveloperName</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Facility</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Child Care</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record__Prior.LicenseDetail__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Operating without licence</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status__c</leftValueReference>
+                <operator>NotEqualTo</operator>
+                <rightValue>
+                    <stringValue>Closed</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Status__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Closed</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Set_OWL_Retention_Fields</targetReference>
+            </connector>
+            <label>Is Child Care OWL</label>
+        </rules>
+        <rules>
+            <name>Is_Residential_Care_OWL</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.RecordType.DeveloperName</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Facility</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Type</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Residential Care</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record__Prior.LicenseDetail__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Operating without licence</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status__c</leftValueReference>
+                <operator>NotEqualTo</operator>
+                <rightValue>
+                    <stringValue>Closed</stringValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Status__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Closed</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Set_OWL_Retention_Fields</targetReference>
+            </connector>
+            <label>Is Residential Care OWL</label>
+        </rules>
+    </decisions>
+    <interviewLabel>PHOCS Account Set OWL Retention On Closure {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>PHOCS Account Set OWL Retention On Closure</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <start>
+        <locationX>50</locationX>
+        <locationY>167</locationY>
+        <connector>
+            <targetReference>Is_Valid_OWL_Closure</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Status__c</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>Closed</stringValue>
+            </value>
+        </filters>
+        <object>Account</object>
+        <recordTriggerType>Update</recordTriggerType>
+        <triggerType>RecordBeforeSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/bcgov-source/app-phocs/main/default/permissionsets/EHIS_Manage_System_Admin_User_PS.permissionset-meta.xml
+++ b/bcgov-source/app-phocs/main/default/permissionsets/EHIS_Manage_System_Admin_User_PS.permissionset-meta.xml
@@ -851,6 +851,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Account.OWLPublicRetentionActive__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Account.OpenFrom__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/bcgov-source/core/main/default/objects/Account/fields/OWLPublicRetentionActive__c.field-meta.xml
+++ b/bcgov-source/core/main/default/objects/Account/fields/OWLPublicRetentionActive__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>OWLPublicRetentionActive__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>EHIS-3375:Live retention flag is 'True' = Closed OWL facility is within 5-year public visibility window anchored to OperationStartDate__c.</description>
+    <label>OWL Public Retention Active</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/bcgov-source/core/main/default/sharingRules/Account.sharingRules-meta.xml
+++ b/bcgov-source/core/main/default/sharingRules/Account.sharingRules-meta.xml
@@ -972,4 +972,29 @@
         </criteriaItems>
         <includeHVUOwnedRecords>false</includeHVUOwnedRecords>
     </sharingGuestRules>
+    <sharingGuestRules>
+        <fullName>PHOCSGuestUserOWLRetentionSharingRule</fullName>
+        <accessLevel>Read</accessLevel>
+        <description>EHIS-3375: Guest users retain Read access to Closed OWL Child Care and Residential Care facilities within the 5-year OperationStartDate retention window.</description>
+        <label>PHOCS Guest User OWL Retention Sharing Rule</label>
+        <sharedTo>
+            <guestUser>phocsservices</guestUser>
+        </sharedTo>
+        <criteriaItems>
+            <field>Status__c</field>
+            <operation>equals</operation>
+            <value>Closed</value>
+        </criteriaItems>
+        <criteriaItems>
+            <field>OWLPublicRetentionActive__c</field>
+            <operation>equals</operation>
+            <value>True</value>
+        </criteriaItems>
+        <criteriaItems>
+            <field>RecordTypeId</field>
+            <operation>equals</operation>
+            <value>PHOCS Facility</value>
+        </criteriaItems>
+        <includeHVUOwnedRecords>false</includeHVUOwnedRecords>
+    </sharingGuestRules>
 </SharingRules>


### PR DESCRIPTION
@msenthilkumar23-dev  Logic is implemented using **OperationEnddate** instead of OperationStartDate.

Before Save flow triggers when status is changed to '**Closed**' and populate **OperationEndDate** field with date the facility is marked as closed and also Make '**OWLPublicRetentionActive__c**' flag TRUE for child Care OWL and residential care OWL.

OWLPublicRetentionActive__c field is used as a flag to expose records. This flag will be flipped to FALSE by nightly batch job if <= 5 years (Post deployment sub task is added to the story).

Sharing rule is created.

Please confirm whether OWLPublicRetentionActive__c field need to be added to Data dictionary.