### PR TITLE
CI deployment Yaml changes

### DIFF
--- a/.github/workflows/PR_Code_Deployment.yml
+++ b/.github/workflows/PR_Code_Deployment.yml
@@ -3,15 +3,10 @@ name: PR Code Deployment
 # Definition when the workflow should run
 on:
   workflow_dispatch:
-  push:
-    branches:
-        - dev
-    paths:
-        - 'bcgov-source/app-phocs/main/default**'
-        - 'bcgov-source/core/main/default**'
-        - 'bcgov-source/app-alr/main/default**'             
-        - '.github/workflows/PR_Code_Deployment.yml'
-        - '!sfdx-project.json'
+  # Scheduled daily deployment at 6 PM Eastern.
+  # NOTE: GitHub cron is UTC and does NOT observe DST. 22:00 UTC = 6 PM EDT (summer) / 5 PM EST (winter).
+  schedule:
+    - cron: '0 22 * * *'
 
 # Jobs to be executed
 jobs:

--- a/.github/workflows/PR_Code_Validation.yml
+++ b/.github/workflows/PR_Code_Validation.yml
@@ -10,6 +10,12 @@ on:
       - 'bcgov-source/app-alr/main/default**'  
       - '.github/workflows/PR_Code_Validation.yml'
       - '!sfdx-project.json'
+
+# Keep only one validation run per PR. A new commit cancels the older, still-running validation.
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Code-Validation-Run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated PR_Code_Deployment Yaml file to trigger on schedule(6:00pm EST everyday) not on every merge.

Added a concurrency group keyed per-PR with cancel-in-progress: true → only one validation run per PR; a new commit cancels the older in-flight run instead of running both.