### PR TITLE
BCMOHAM-34464 || Updated Validation Rule

### DIFF
--- a/bcgov-source/core/main/default/objects/Visit/validationRules/UpdateStartTimeToCurrentOrPast.validationRule-meta.xml
+++ b/bcgov-source/core/main/default/objects/Visit/validationRules/UpdateStartTimeToCurrentOrPast.validationRule-meta.xml
@@ -6,7 +6,7 @@
     <errorConditionFormula>AND(
     NOT($Permission.EHISBypassValidationRuleCustomPermission),
     RecordType.DeveloperName = &apos;Inspection&apos;,
-     ActualVisitStartTime &gt; NOW(),
+     ActualVisitStartTime &gt; NOW() + (1/1440),
     ISPICKVAL( Status , &quot;In Progress&quot;) 
 )</errorConditionFormula>
     <errorMessage>Update Actual Start Time to a current or past date.</errorMessage>


### PR DESCRIPTION
Updated the validation rule to allow a one-minute tolerance for system-generated start times. This will prevent false validation failures while continuing to block start times that are genuinely set in the future.

https://proactionca.ent.cgi.com/jira/browse/BCMOHAM-34464